### PR TITLE
히트맵 드래그 기능 및 새 탭 이동 기능 개발진행중

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" default="true" project-jdk-name="18" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
+  </component>
+  <component name="ProjectType">
+    <option name="id" value="jpab" />
   </component>
 </project>

--- a/src/main/java/imqa/dashboard/mpm/ReportAppVer.java
+++ b/src/main/java/imqa/dashboard/mpm/ReportAppVer.java
@@ -2,33 +2,19 @@ package imqa.dashboard.mpm;
 
 
 import com.common.Constant;
-import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.By;
-import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
-import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 public class ReportAppVer {
 
-    private final WebDriver driver;
+    private static WebDriver driver;
 
     private Constant constant;
-
-    public static void main(String[] args) throws Exception {
-        System.out.println("Say Run");
-        while (true) {
-            try {
-                new ReportAppVer().run();
-            } catch (Exception e) {
-
-            }
-        }
-    }
 
 
     public ReportAppVer() {
@@ -39,85 +25,477 @@ public class ReportAppVer {
         driver.manage().window().maximize();
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
         driver.get("https://account.imqa.io/user/login");
-
     }
 
-    public void run() throws Exception {
+    private static void setReportLogin() {
 
+
+
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
         WebElement idField = driver.findElement(By.cssSelector("html > body > div > div > div > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(2) > form > div:nth-of-type(1) > div:nth-of-type(1) > input"));
-        idField.sendKeys(constant.devEmail);
+        setReportLogOut();
 
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+        idField.sendKeys("devload@naver.com");
 
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
         WebElement passwordField = driver.findElement(By.cssSelector("html > body > div > div > div > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(2) > form > div:nth-of-type(2) > div:nth-of-type(1) > input"));
-        passwordField.sendKeys(constant.devPassword);
+        passwordField.sendKeys("sh583582!23$");
 
-
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
         WebElement loginButton = driver.findElement(By.cssSelector("button[class='submit']"));
         loginButton.click();
 
-
-        //todo 앱버전이 하나인 계정으로 로그인시
-//        WebElement goMpm = driver.findElement(By.cssSelector("html > body > div:nth-of-type(1) > div > div:nth-of-type(2) > div:nth-of-type(2) > table > tbody > tr:nth-of-type(1) > td:nth-of-type(2) > div"));
-//        goMpm.click();
-//        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
-
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
         WebElement MoreProjectsButton = driver.findElement(By.cssSelector("button[class='more-btn']"));
         MoreProjectsButton.click();
 
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
-
         WebElement TestMpm = driver.findElement(By.cssSelector("html > body > div:nth-of-type(1) > div > div:nth-of-type(3) > div:nth-of-type(2) > table > tbody > tr:nth-of-type(39) > td:nth-of-type(2)"));
         TestMpm.click();
 
         WebElement goReport = driver.findElement(By.cssSelector("html > body > div > div > header > div:nth-of-type(2) > div > ul > div:nth-of-type(5) > li > a > span"));
         goReport.click();
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+    }
+
+    private static void setReportLogOut() {
+        WebElement LogOutSideBar = driver.findElement(By.cssSelector("div[class='header-dropdown'] div[class='content']"));
+        LogOutSideBar.click();
+
+        WebElement LogOut = driver.findElement(By.cssSelector("html > body > div > div > header > div:nth-of-type(6) > div:nth-of-type(3) > ul > li:nth-of-type(4) > a > span"));
+        LogOut.click();
+    }
 
 
-        Thread.sleep(5000);
 
-        //AppVer1 (HY 프레딧 AOS 프로젝트 기준)
+    public static boolean ReportTest1() {
+
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
         WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
         AppVerDropBox.click();
 
-        WebElement AppVerDroBoxSelect1 = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(1) > button"));
-        AppVerDroBoxSelect1.click();
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
 
         WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
         ReportAppVerApplyButton.click();
-
-        WebElement ReportFirstPage = driver.findElement(By.cssSelector("div[id='page1'] div[class='report-container']"));
-        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
-        File file=ReportFirstPage.getScreenshotAs(OutputType.FILE);
-        FileUtils.copyFile(file, new File("app1logo.png"));
-        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
-        //파일 스크린샷 코드 추가
-
-        //AppVer2 (HY 프레딧 AOS 프로젝트 기준)
-        WebElement AppVerDropBox2 = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
-        AppVerDropBox2.click();
-
-        WebElement AppVerDroBoxSelect2 = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
-        AppVerDroBoxSelect2.click();
-
-        WebElement ReportAppVerApplyButton2 = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
-        ReportAppVerApplyButton2.click();
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
 
-        WebElement Report2ElementConfirm = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(1) > table > tbody > tr > td:nth-of-type(2)"));
-        Report2ElementConfirm.getText();
+        WebElement ReportNativeLoading = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(1) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportNativeLoading.getText();
 
-        WebElement Report2ElementConfirm2 = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(3) > table > tbody > tr > td:nth-of-type(2)"));
-        Report2ElementConfirm2.getText();
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
 
-        WebElement Report2ElementConfirm3 = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(5) > table > tbody > tr > td:nth-of-type(6)"));
-        Report2ElementConfirm3.getText();
+    public static boolean ReportTest2 () {
 
-
-
-        WebElement ReportFirstPage2 = driver.findElement(By.cssSelector("div[id='page1'] div[class='report-container']"));
+        setReportLogin();
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
-        File file2 = ReportFirstPage2.getScreenshotAs(OutputType.FILE);
-        FileUtils.copyFile(file2, new File("app2logo.png"));
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement ReportWebViewLoading = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(2) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportWebViewLoading.getText();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest3 () {
+
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement ReportResponse = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(3) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportResponse.getText();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest4 () {
+
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement ReportCpuUsage = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(4) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportCpuUsage.getText();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest5 () {
+
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement ReportMemoryUsage = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(5) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportMemoryUsage.getText();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest6 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement NativeUiRenderingBar = driver.findElement(By.cssSelector("span[class='uiRenderingBottom']"));
+        NativeUiRenderingBar.getText();
+
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest7 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+
+        //표본의 2번째 데이터 존재 유무로 테스트 성공실패를 판단, td.type을 1로 수정하고 isDisplayed를 getText로 하면 하나의 값을 알 수 있다.
+        WebElement ReportScreenTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(1) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportScreenTable.isDisplayed();
+
+        WebElement ReportOsVersionTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(2) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportOsVersionTable.isDisplayed();
+
+        WebElement ReportDeviceTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(3) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportDeviceTable.isDisplayed();
+
+        WebElement ReportLocationTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(4) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportLocationTable.isDisplayed();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest8 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement CpuUsageBar = driver.findElement(By.cssSelector("span[class='cpuBottom']"));
+        CpuUsageBar.getText();
+
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest9 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        //표본의 2번째 데이터 존재 유무로 테스트 성공실패를 판단, td.type을 1로 수정하고 isDisplayed를 getText로 하면 하나의 값을 알 수 있다.
+        WebElement ReportScreenTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(3) > div:nth-of-type(2) > div:nth-of-type(1) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportScreenTable.isDisplayed();
+
+        WebElement ReportOsVersionTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(3) > div:nth-of-type(2) > div:nth-of-type(2) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportOsVersionTable.isDisplayed();
+
+        WebElement ReportDeviceTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(3) > div:nth-of-type(2) > div:nth-of-type(3) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportDeviceTable.isDisplayed();
+
+        WebElement ReportLocationTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(3) > div:nth-of-type(2) > div:nth-of-type(4) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportLocationTable.isDisplayed();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest10 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement MemoryBar = driver.findElement(By.cssSelector("span[class='memoryBottom']"));
+        MemoryBar.getText();
+
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest11 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        //표본의 2번째 데이터 존재 유무로 테스트 성공실패를 판단, td.type을 1로 수정하고 isDisplayed를 getText로 하면 하나의 값을 알 수 있다.
+        WebElement ReportScreenTable = driver.findElement(By.cssSelector("hhtml > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(4) > div:nth-of-type(2) > div:nth-of-type(1) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportScreenTable.isDisplayed();
+
+        WebElement ReportOsVersionTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(4) > div:nth-of-type(2) > div:nth-of-type(2) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportOsVersionTable.isDisplayed();
+
+        WebElement ReportDeviceTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(4) > div:nth-of-type(2) > div:nth-of-type(3) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportDeviceTable.isDisplayed();
+
+        WebElement ReportLocationTable = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(4) > div:nth-of-type(2) > div:nth-of-type(4) > table > tbody > tr > td:nth-of-type(2)"));
+        ReportLocationTable.isDisplayed();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+
+    public static boolean ReportTest12 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement UrlResponseAverage = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(5) > div:nth-of-type(2) > div > table > tbody > tr:nth-of-type(1) > td:nth-of-type(6)"));
+        UrlResponseAverage.getText();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest13 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement UrlP95ResponseAverage = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(5) > div:nth-of-type(2) > div > table > tbody > tr:nth-of-type(1) > td:nth-of-type(7)"));
+        UrlP95ResponseAverage.getText();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest14 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement WebViewLoadingAverage = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(6) > div:nth-of-type(2) > div > table > tbody > tr:nth-of-type(1) > td:nth-of-type(4)"));
+        WebViewLoadingAverage.getText();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
+    }
+
+    public static boolean ReportTest15 () {
+        setReportLogin();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement AppVerDropBox = driver.findElement(By.cssSelector("button[class='version-dropdown-btn']"));
+        AppVerDropBox.click();
+
+        WebElement AppVerDroBoxSelect = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(1) > div:nth-of-type(3) > div:nth-of-type(2) > ul > li:nth-of-type(2) > button"));
+        AppVerDroBoxSelect.click();
+
+        WebElement ReportAppVerApplyButton = driver.findElement(By.cssSelector("button[class='version-apply-btn']"));
+        ReportAppVerApplyButton.click();
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+
+        WebElement WebViewP95LoadingAverage = driver.findElement(By.cssSelector("html > body > div > div > section > div > div:nth-of-type(2) > div:nth-of-type(6) > div:nth-of-type(2) > div > table > tbody > tr:nth-of-type(1) > td:nth-of-type(5)"));
+        WebViewP95LoadingAverage.getText();
+
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            System.out.println("로그아웃 타임아웃으로 실패했습니다.");
+        }
+        setReportLogOut();
+        return true;
     }
 }

--- a/src/main/java/imqa/dashboard/runner/ClickAction.java
+++ b/src/main/java/imqa/dashboard/runner/ClickAction.java
@@ -19,7 +19,7 @@ public class ClickAction implements SeleniumAction {
     @Override
     public void run(WebDriver driver, ScenarioVo scenario) {
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
-        WebElement loginButton = driver.findElement(By.cssSelector(dao.findByElement(scenario).getCssSelect()));
-        loginButton.click();
+        WebElement clickAction = driver.findElement(By.cssSelector(dao.findByElement(scenario).getCssSelect()));
+        clickAction.click();
     }
 }

--- a/src/main/java/imqa/dashboard/runner/ElementConfirm.java
+++ b/src/main/java/imqa/dashboard/runner/ElementConfirm.java
@@ -16,7 +16,8 @@ public class ElementConfirm implements SeleniumAction{
 
     @Override
     public void run(WebDriver driver, ScenarioVo scenario) {
-        WebElement ReportNativeLoading = driver.findElement(By.cssSelector(dao.findByElement(scenario).getCssSelect()));
-        ReportNativeLoading.getText();
+        WebElement elementConfirm = driver.findElement(By.cssSelector(dao.findByElement(scenario).getCssSelect()));
+        elementConfirm.getText();
     }
 }
+

--- a/src/main/java/imqa/dashboard/runner/ElementDrag.java
+++ b/src/main/java/imqa/dashboard/runner/ElementDrag.java
@@ -8,10 +8,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 
 public class ElementDrag implements SeleniumAction {
-
     private MetricDao dao;
-//    ScenarioVo scenario;
-
 
     public ElementDrag(MetricDao dao) {
         this.dao = dao;
@@ -20,20 +17,20 @@ public class ElementDrag implements SeleniumAction {
     @Override
     public void run(WebDriver driver, ScenarioVo scenario) {
         String[] selectors = scenario.getParams().split(",");
-        if (selectors.length == 2) {
+        if (selectors.length >= 2) {
             String startSelector = selectors[0].trim();
             String endSelector = selectors[1].trim();
 
-            WebElement startElement = driver.findElement(By.cssSelector(startSelector));
-            WebElement endElement = driver.findElement(By.cssSelector(endSelector));
+                WebElement startElement = driver.findElement(By.cssSelector(startSelector));
+                WebElement endElement = driver.findElement(By.cssSelector(endSelector));
 
-            Actions actions = new Actions(driver);
-            actions.clickAndHold(startElement).moveToElement(endElement).perform();
+                Actions builder = new Actions(driver);
+                builder.dragAndDrop(startElement, endElement).perform();
+            } else {
+                System.out.println("드래그못함");
+            }
 
-
-        } else {
-            System.out.println("드래그함");
-        }
     }
+
 
 }

--- a/src/main/java/imqa/dashboard/runner/ElementDrag.java
+++ b/src/main/java/imqa/dashboard/runner/ElementDrag.java
@@ -1,0 +1,39 @@
+package imqa.dashboard.runner;
+
+import imqa.dashboard.dao.MetricDao;
+import imqa.dashboard.vo.ScenarioVo;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+
+public class ElementDrag implements SeleniumAction {
+
+    private MetricDao dao;
+//    ScenarioVo scenario;
+
+
+    public ElementDrag(MetricDao dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public void run(WebDriver driver, ScenarioVo scenario) {
+        String[] selectors = scenario.getParams().split(",");
+        if (selectors.length == 2) {
+            String startSelector = selectors[0].trim();
+            String endSelector = selectors[1].trim();
+
+            WebElement startElement = driver.findElement(By.cssSelector(startSelector));
+            WebElement endElement = driver.findElement(By.cssSelector(endSelector));
+
+            Actions actions = new Actions(driver);
+            actions.clickAndHold(startElement).moveToElement(endElement).perform();
+
+
+        } else {
+            System.out.println("드래그함");
+        }
+    }
+
+}

--- a/src/main/java/imqa/dashboard/runner/InputAction.java
+++ b/src/main/java/imqa/dashboard/runner/InputAction.java
@@ -20,8 +20,8 @@ public class InputAction implements SeleniumAction{
     @Override
     public void run(WebDriver driver, ScenarioVo scenario) {
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
-        WebElement idField = driver.findElement(By.cssSelector(dao.findByElement(scenario).getCssSelect()));
-        idField.sendKeys(scenario.getParams());
+        WebElement inputParams = driver.findElement(By.cssSelector(dao.findByElement(scenario).getCssSelect()));
+        inputParams.sendKeys(scenario.getParams());
 
     }
 

--- a/src/main/java/imqa/dashboard/runner/NewTabConfirm.java
+++ b/src/main/java/imqa/dashboard/runner/NewTabConfirm.java
@@ -1,0 +1,27 @@
+package imqa.dashboard.runner;
+
+import imqa.dashboard.dao.MetricDao;
+import imqa.dashboard.vo.ScenarioVo;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.concurrent.TimeUnit;
+
+public class NewTabConfirm implements SeleniumAction {
+
+    MetricDao dao;
+
+    NewTabConfirm(MetricDao dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public void run(WebDriver driver, ScenarioVo scenario) {
+        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+        WebElement NewTabConfirm = driver.findElement(By.cssSelector(dao.findByElement(scenario).getCssSelect()));
+        String CurrentUrl = driver.getCurrentUrl();
+        driver.get(CurrentUrl);
+        NewTabConfirm.getText();
+    }
+}

--- a/src/test/java/imqa/dashboard/excelread/PoiReadExcelTest.java
+++ b/src/test/java/imqa/dashboard/excelread/PoiReadExcelTest.java
@@ -40,9 +40,6 @@ public class PoiReadExcelTest {
                 return result;
             }
         }.readExcel();
-
-
-
     }
 
 }

--- a/src/test/java/imqa/dashboard/mpm/ScenarioDaoTest.java
+++ b/src/test/java/imqa/dashboard/mpm/ScenarioDaoTest.java
@@ -15,7 +15,7 @@ public class ScenarioDaoTest {
     @Test
     public void scenarioDao() throws IOException {
 
-        List<ScenarioVo> result = new ScenarioDao(new File("/Users/id_sucheol/Downloads/화면분석 시나리오.xlsx")).readExcel();
+        List<ScenarioVo> result = new ScenarioDao(new File("/Users/id_sucheol/Desktop/SellyExcel/프로젝트 관리와 화면관리 시나리오.xlsx")).readExcel();
 
         System.out.println(result);
 

--- a/src/test/java/imqa/dashboard/runner/SeleniumContextTest.java
+++ b/src/test/java/imqa/dashboard/runner/SeleniumContextTest.java
@@ -12,11 +12,11 @@ public class SeleniumContextTest {
     @Test
     public void seleniumTest() throws IOException {
 
-        MetricDao metricDao = new MetricDao(new File("/Users/id_sucheol/Downloads/MatricList.xlsx"));
+        MetricDao metricDao = new MetricDao(new File("/Users/id_sucheol/Desktop/SellyExcel/MatricListF.xlsx"));
 
         SeleniumContext context = new SeleniumContext(metricDao);
 
-        ScenarioDao scenarioDao = new ScenarioDao(new File("/Users/id_sucheol/Downloads/login.xlsx"));
+        ScenarioDao scenarioDao = new ScenarioDao(new File("/Users/id_sucheol/Desktop/SellyExcel/화면카드 상세 시나리오 리스트.xlsx"));
 
         context.run(scenarioDao.readExcel());
 


### PR DESCRIPTION
기존의 히트맵 데이터 상세 조회기능은 엑셀파일을 작성할 때 타임라인값, 히트맵의 개별 ID를 통해서 진입했습니다.
SaaS 모니터링 적용시 타임라인을 지정하는 기능이 필요없을 것 같아서 제외했고, DragToDrop 및 ClickHold로 드래그 기능을 만들어서 모든 그래프에 일괄적으로 적용하려고 합니다.

새탭 이동 기능은 기존탭에서 원하는 엘리먼트가 없을 시 기존 탭을 삭제하고, 새로 만들어진 탭에서 동작하기 위한 기능입니다. 
여러개의 테스트를 한꺼번에 동작했을 때 오류가 난 테스트의 브라우저탭만 남기는 방식으로 진행하려고 합니다.